### PR TITLE
chore(docker): make compose image tag durable instead of a fixed pin

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -2,7 +2,10 @@ services:
   service-media_stream:
     container_name: service-media_stream
     restart: no
-    image: gro0ve/grooveshop-media-stream:v2.58.0
+    # Defaults to the CI-maintained `latest` tag (published on every release) so
+    # this dev compose never drifts a version behind. Pin a specific release for
+    # reproducibility with MEDIA_STREAM_IMAGE_TAG=v2.58.1.
+    image: gro0ve/grooveshop-media-stream:${MEDIA_STREAM_IMAGE_TAG:-latest}
     env_file:
       - ./grooveshop-media-stream/.env.docker
     ports:


### PR DESCRIPTION
## Summary

The `docker/compose.yaml` image was pinned to a fixed release (`v2.58.0`), which drifts one version behind on every `semantic-release` publish — the same staleness the audit corrected when it bumped the pin up from the 150-releases-old `v1.102.1`. The release the audit merge triggered (`v2.58.1`) re-staled the pin.

This replaces the hardcoded pin with `${MEDIA_STREAM_IMAGE_TAG:-latest}`:
- **Default `latest`** — the CI (`docker.yml`) publishes `latest` on every release, so this dev compose tracks the current image and never silently drifts.
- **Override for reproducibility** — set `MEDIA_STREAM_IMAGE_TAG=v2.58.1` to pin a specific release.

Verified with `docker compose config`: default renders `…:latest`, override renders `…:v2.58.1`.

Note: this is the local/dev compose convenience file, not the production K8s deploy (which lives in the infrastructure repo). No application code changes; `chore:` so it does not trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment to support selecting the media streaming service image version through an environment setting.
  * The image defaults to the latest available version when no setting is provided.
  * Documented versioning expectations to help maintain consistent and reproducible development and CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->