### PR TITLE
fix(config): don't cap monitoring collection intervals (startup crash)

### DIFF
--- a/src/MediaStream/Config/dto/monitoring-config.dto.ts
+++ b/src/MediaStream/Config/dto/monitoring-config.dto.ts
@@ -1,17 +1,21 @@
-import { IsBoolean, IsNumber, Max, Min } from 'class-validator'
+import { IsBoolean, IsNumber, Min } from 'class-validator'
 
 export class MonitoringConfigDto {
 	@IsBoolean()
 	enabled: boolean = true
 
-	// Metrics collection intervals (in milliseconds)
+	// Metrics collection intervals (in milliseconds). Only a lower bound is
+	// enforced: collecting too frequently wastes CPU, but a larger interval
+	// (collect less often) is always safe — there is no meaningful upper cap.
+	// A previous @Max(300000)/@Max(120000) here rejected legitimate
+	// production intervals (e.g. 30-minute system / 10-minute performance),
+	// crashing startup once config validation began running against the
+	// schema-built config.
 	@IsNumber()
 	@Min(10000) // Minimum 10 seconds
-	@Max(300000) // Maximum 5 minutes
 	systemMetricsInterval: number = 60000
 
 	@IsNumber()
 	@Min(5000) // Minimum 5 seconds
-	@Max(120000) // Maximum 2 minutes
 	performanceMetricsInterval: number = 30000
 }

--- a/src/test/Config/config.service.spec.ts
+++ b/src/test/Config/config.service.spec.ts
@@ -145,6 +145,24 @@ describe('configService', () => {
 			await expect(invalidService.validate()).rejects.toThrow('Configuration validation failed')
 		})
 
+		it('should accept production-scale monitoring intervals (regression: startup crash)', async () => {
+			// The production ConfigMap uses 30-min system / 10-min performance
+			// intervals. A spurious @Max on these previously failed validation and
+			// crash-looped the pod once validation ran against the built config.
+			nestConfigService.get.mockImplementation((key: string) => {
+				if (key === 'MONITORING_SYSTEM_METRICS_INTERVAL')
+					return '1800000'
+				if (key === 'MONITORING_PERFORMANCE_METRICS_INTERVAL')
+					return '600000'
+				return mockEnvVars[key as keyof typeof mockEnvVars]
+			})
+
+			const service = new ConfigService(nestConfigService)
+			expect(service.get('monitoring.systemMetricsInterval')).toBe(1800000)
+			expect(service.get('monitoring.performanceMetricsInterval')).toBe(600000)
+			await expect(service.validate()).resolves.not.toThrow()
+		})
+
 		it('should validate processing configuration', async () => {
 			nestConfigService.get.mockImplementation((key: string) => {
 				if (key === 'PROCESSING_CPU_CORES')

--- a/src/test/Config/dto/app-config.dto.spec.ts
+++ b/src/test/Config/dto/app-config.dto.spec.ts
@@ -66,8 +66,10 @@ describe('appConfigDto', () => {
 				},
 				monitoring: {
 					enabled: true,
-					systemMetricsInterval: 60000,
-					performanceMetricsInterval: 30000,
+					// Production-scale intervals (30-min system / 10-min performance):
+					// these previously exceeded a spurious @Max and crashed startup.
+					systemMetricsInterval: 1800000,
+					performanceMetricsInterval: 600000,
 				},
 				externalServices: {
 					requestTimeout: 30000,


### PR DESCRIPTION
## Problem

The v2.58.1 rollout **CrashLoopBackOff'd in production**: `ConfigService.validate()` threw at `onModuleInit` and the pod never became ready (old pods kept serving via `maxUnavailable: 0`, so no outage).

```
Configuration validation failed:
  monitoring.systemMetricsInterval must not be greater than 300000;
  monitoring.performanceMetricsInterval must not be greater than 120000
```

`MonitoringConfigDto` capped these at `@Max(300000)` (5min) / `@Max(120000)` (2min). Pre-consolidation those env values were never validated (excluded from the old validation object — the "phantom keys" the audit documented). Once the audit made validation run against the schema-built config, the production ConfigMap's legitimate **30-minute system / 10-minute performance** intervals (`1800000` / `600000`) tripped the cap and crashed startup.

Local smoke passed earlier only because `.env.example` uses values under the cap — the gap being closed here by testing production-scale values.

## Fix

A metric-collection *interval* has a meaningful **lower** bound (don't hammer the system) but no upper safety bound — collecting less often is always fine. Removed the spurious `@Max` on both (kept `@Min`).

## Verification

- Boot with `NODE_ENV=production` + the real `1800000`/`600000` intervals → **"Configuration validation passed" → "Nest application successfully started"**, `/health/live` 200.
- New `ConfigService` regression test validates those exact production values; the app-config DTO "valid configuration" case now uses production-scale intervals.
- Full suite green (890 unit + 9 e2e), coverage above thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Monitoring configuration now accepts longer, production-scale intervals for system and performance metrics.
  * Configuration validation continues to enforce numeric values and minimum intervals without rejecting legitimate higher values.

* **Tests**
  * Added coverage confirming production-scale monitoring intervals are accepted during configuration validation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->